### PR TITLE
Add debug logs for pawning and silence auth logs

### DIFF
--- a/controllers/pawning.ticket.controller.js
+++ b/controllers/pawning.ticket.controller.js
@@ -1633,12 +1633,16 @@ export const getTicketDataById = async (req, res, next) => {
       );
     }
 
+    console.log(
+      pawningCustomer[0].accountCenterCusId,
+      "pawning customer account center cus id",
+    );
     // Fetch full details from Account Center company_customer via subsystem API
     const accCustomers = await subsystemApi.customerDataForPawningTicketView(
       pawningCustomer[0].accountCenterCusId,
       req.accessToken,
     );
-
+    console.log(accCustomers, "acc customers");
     if (accCustomers.data) {
       const accCus = accCustomers.data;
 

--- a/middlewares/auth.middleware.js
+++ b/middlewares/auth.middleware.js
@@ -16,11 +16,11 @@ export const protectedRoute = async (req, res, next) => {
 
     // Verify the token
     try {
-      console.log(`[protectedRoute] Verifying token for path: ${req.path}`);
-      console.log(`[protectedRoute] Token: ${accessToken}`);
+      // console.log(`[protectedRoute] Verifying token for path: ${req.path}`);
+      //console.log(`[protectedRoute] Token: ${accessToken}`);
 
       const decoded = jwt.verify(accessToken, process.env.JWT_ACCESS_SECRET);
-      console.log(`[protectedRoute] Decoded Token:`, decoded);
+      // console.log(`[protectedRoute] Decoded Token:`, decoded);
 
       const [user] = await pool2.query(
         "SELECT idUser FROM user WHERE idUser = ? and Email = ? and Company_idCompany = ? and Designation_idDesignation = ?",


### PR DESCRIPTION
Add temporary console.debug output in pawning.ticket.controller to log accountCenterCusId and the fetched accCustomers for troubleshooting the ticket view. In auth.middleware, comment out verbose console.log statements that printed the access token and decoded token to reduce sensitive logging noise. These are intended as short-term debugging changes.